### PR TITLE
#23 Fixed footer overflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
   return (
     <Router>
       <ScrollToTop />
-      <div className="App w-screen overflow-x-hidden font-Roboto selection:bg-yellow-400 selection:text-gray-900">
+      <div className="App w-screen overflow-x-hidden font-Roboto selection:bg-yellow-400 selection:text-gray-900 flex flex-col min-h-screen	justify-between">
         <Navbar />
         <Routes>
           <Route path="/" element={<Home />} />


### PR DESCRIPTION
The footer spacing problem was present on the sponsors, contact us, and projects page. It should be fixed on all the pages now. 